### PR TITLE
Campaign cost calculator

### DIFF
--- a/src/extensions/service-managers/campaign-cost-calculator/LICENSE
+++ b/src/extensions/service-managers/campaign-cost-calculator/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 The Australian Greens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -10,7 +10,7 @@ of costs.
 
 - [PostgreSQL](https://www.postgresql.org/)
 
-This extension has been tested against PostgresSQL 11 specifically.
+This extension has been tested against PostgreSQL 11 specifically.
 Your mileage may vary with other versions (but shouldn't).
 
 You will need administrator privileges in your database to perform installation.
@@ -21,13 +21,13 @@ You will need administrator privileges in your database to perform installation.
 
 1. Add `campaign-cost-calculator` to your `SERVICE_MANAGERS` variable
 2. Add `CAMPAIGN_COST_CURRENCY` and assign it a three letter currency code in quotes (eg. `CAMPAIGN_COST_CURRENCY='USD'`)
-3. Add `CAMPAIGN_COST_INBOUND` and assign it the inbound price per segment (eg. `CAMPAIGN_COST_INBOUND=0.0025`)
-4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound price per segment (eg. `CAMPAIGN_COST_OUTBOUND=0.055`)
+3. Add `CAMPAIGN_COST_INBOUND` and assign it the inbound price per segment (eg. `CAMPAIGN_COST_INBOUND=0.0075`)
+4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound price per segment (eg. `CAMPAIGN_COST_OUTBOUND=0.049`)
 
 ### Configure PostgreSQL
 
 Use `psql` or your preferred database client and connect as an administrator
-to your postgresql Spoke database. Then run the following commands:
+to your PostgreSQL Spoke database. Then run the following commands:
 
 1. Install your language extension
 
@@ -148,5 +148,5 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
 ## Acknowledgements
 
-The code to calculate the number of segments is strongly based on 
-[danxexe's sms-counter project](https://github.com/danxexe/sms-counter).
+The code to calculate the number of segments is an adaptation of 
+[danxexe's sms-counter project](https://github.com/danxexe/sms-counter) work from JavaScript to PL/pgsql.

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -21,8 +21,8 @@ You will need administrator privileges in your database to perform installation.
 
 1. Add `campaign-cost-calculator` to your `SERVICE_MANAGERS` variable
 2. Add `CAMPAIGN_COST_CURRENCY` and assign it a three letter currency code in quotes (eg. `CAMPAIGN_COST_CURRENCY='USD'`)
-3. Add `CAMPAIGN_COST_INBOUND` and assign it the number (eg. `CAMPAIGN_COST_INBOUND=0.0025`)
-4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound pricea (eg. `CAMPAIGN_COST_OUTBOUND=0.055`)
+3. Add `CAMPAIGN_COST_INBOUND` and assign it the inbound price per segment (eg. `CAMPAIGN_COST_INBOUND=0.0025`)
+4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound price per segment (eg. `CAMPAIGN_COST_OUTBOUND=0.055`)
 
 ### Configure PostgreSQL
 

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -9,10 +9,9 @@ of costs.
 ## Requirements
 
 - [PostgreSQL](https://www.postgresql.org/)
-- [PL/v8 language extension for PostgreSQL](https://plv8.github.io/)
 
 This extension has been tested against PostgresSQL 11 specifically.
-Your mileage may vary with other versions.
+Your mileage may vary with other versions (but shouldn't).
 
 You will need administrator privileges in your database to perform installation.
 

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -1,0 +1,104 @@
+// Run the following commands in your Spoke database to set up
+// the required code to support the Twilio Cost Calculator service manager
+
+// 1. Enable the PLV8 language extension
+CREATE EXTENSION plv8;
+
+// 2. Function to detect SMS message encoding
+
+CREATE OR REPLACE FUNCTION SMSDetectEncoding(msg TEXT) RETURNS INT AS $$
+  const gsm7bitChars = "@£$¥èéùìòÇ\\nØø\\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\\\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
+  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+  const gsm7bitRegExp = RegExp("^[" + gsm7bitChars + "]*$");
+  const gsm7bitExRegExp = RegExp("^[" + gsm7bitChars + gsm7bitExChar + "]*$");
+  switch (false) {
+    case msg.match(gsm7bitRegExp) == null:
+      return 1;
+    case msg.match(gsm7bitExRegExp) == null:
+      return 2;
+    default:
+      return 3;
+  }
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+// 3. Function to count extended GSM-7 message length
+
+CREATE OR REPLACE FUNCTION SMSCountGSMExt(msg TEXT) RETURNS INT AS $$
+  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+  const gsm7bitExOnlyRegExp = RegExp("^[\\" + gsm7bitExChar + "]*$");
+  var char2, chars;
+  chars = (function() {
+    var _i, _len, _results;
+    _results = [];
+    for (_i = 0, _len = msg.length; _i < _len; _i++) {
+      char2 = msg[_i];
+      if (char2.match(this.gsm7bitExOnlyRegExp) != null) {
+        _results.push(char2);
+      }
+    }
+    return _results;
+  }).call(this);
+  return chars.length;
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+// 4. Calculate number of segments for message
+
+CREATE OR REPLACE FUNCTION SMSSegments(msg TEXT) RETURNS INT AS $$
+  const messageLength = {
+    1: 160,
+    2: 160,
+    3: 70
+  };
+  const multiMessageLength = {
+    1: 153,
+    2: 153,
+    3: 67
+  };
+  let fnDetect = plv8.find_function("SMSDetectEncoding", msg);
+  let fnCountExt = plv8.find_function("SMSCountGSMExt", msg);
+  let remaining;
+  const encoding = fnDetect(msg);
+  let length = msg.length;
+  if (encoding === 2) {
+    length += fnCountExt(msg);
+  }
+  let per_message = messageLength[encoding];
+  if (length > per_message) {
+    per_message = multiMessageLength[encoding];
+  }
+  let segments = Math.ceil(length / per_message);
+  remaining = (per_message * segments) - length;
+  if(remaining == 0 && segments == 0){
+    remaining = per_message;
+  }
+  return segments;
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+// 5. Calculate total cost of campaign
+
+CREATE OR REPLACE FUNCTION SMSCampaignCost(cid INT) RETURNS JSON AS $$
+  const campaignId = cid;
+  const outboundPrice = 0.075;
+  const inboundPrice = 0.0049;
+  let fnCount = plv8.find_function("SMSSegments");
+  const messages = plv8.execute('SELECT m.text, m.is_from_contact FROM message m INNER JOIN campaign_contact cc ON cc.id = m.campaign_contact_id WHERE cc.campaign_id = $1',[ campaignId ]);
+
+  let outboundSegments = 0;
+  let inboundSegments = 0;
+  let outboundCost = 0;
+  let inboundCost = 0;
+  for (let i = 0; i < messages.length; i++) {
+    (messages[i].is_from_contact)
+    ? inboundSegments += fnCount(messages[i].text)
+    : outboundSegments += fnCount(messages[i].text);
+  }
+  outboundCost = outboundSegments * outboundPrice;
+  inboundCost = inboundSegments * inboundPrice;
+
+  return {
+    outboundCost: outboundCost,
+    inboundCost: inboundCost,
+    totalCost: outboundCost + inboundCost
+  }
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -23,7 +23,7 @@ You will need administrator privileges in your database to perform installation.
 1. Add `campaign-cost-calculator` to your `SERVICE_MANAGERS` variable
 2. Add `CAMPAIGN_COST_CURRENCY` and assign it a three letter currency code in quotes (eg. `CAMPAIGN_COST_CURRENCY='USD'`)
 3. Add `CAMPAIGN_COST_INBOUND` and assign it the number (eg. `CAMPAIGN_COST_INBOUND=0.0025`)
-4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound pricea (eg. `CAMPAIGN_COST_OUTBOUND=0.055`) 
+4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound pricea (eg. `CAMPAIGN_COST_OUTBOUND=0.055`)
 
 ### Configure PostgreSQL
 
@@ -32,103 +32,115 @@ to your postgresql Spoke database. Then run the following commands:
 
 1. Install the PL/v8 language extension
 
-`CREATE EXTENSION plv8;`
+```
+CREATE EXTENSION plv8;
+```
 
-    CREATE OR REPLACE FUNCTION SMSDetectEncoding(msg TEXT) RETURNS INT AS $$
-      const gsm7bitChars = "@£$¥èéùìòÇ\\nØø\\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\\\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
-      const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
-      const gsm7bitRegExp = RegExp("^[" + gsm7bitChars + "]*$");
-      const gsm7bitExRegExp = RegExp("^[" + gsm7bitChars + gsm7bitExChar + "]*$");
-      switch (false) {
-        case msg.match(gsm7bitRegExp) == null:
-          return 1;
-        case msg.match(gsm7bitExRegExp) == null:
-          return 2;
-        default:
-          return 3;
+2. Create a function to detect message encoding
+
+```
+CREATE OR REPLACE FUNCTION SMSDetectEncoding(msg TEXT) RETURNS INT AS $$
+  const gsm7bitChars = "@£$¥èéùìòÇ\\nØø\\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\\\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
+  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+  const gsm7bitRegExp = RegExp("^[" + gsm7bitChars + "]*$");
+  const gsm7bitExRegExp = RegExp("^[" + gsm7bitChars + gsm7bitExChar + "]*$");
+  switch (false) {
+    case msg.match(gsm7bitRegExp) == null:
+      return 1;
+    case msg.match(gsm7bitExRegExp) == null:
+      return 2;
+    default:
+      return 3;
+  }
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
+
+3. Create a function to count extended GSM-7 messages
+
+```
+CREATE OR REPLACE FUNCTION SMSCountGSMExt(msg TEXT) RETURNS INT AS $$
+  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+  const gsm7bitExOnlyRegExp = RegExp("^[\\" + gsm7bitExChar + "]*$");
+  var char2, chars;
+  chars = (function() {
+    var _i, _len, _results;
+    _results = [];
+    for (_i = 0, _len = msg.length; _i < _len; _i++) {
+      char2 = msg[_i];
+      if (char2.match(this.gsm7bitExOnlyRegExp) != null) {
+        _results.push(char2);
       }
-    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+    }
+    return _results;
+  }).call(this);
+  return chars.length;
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
 
-2. Create a function to count extended GSM-7 messages
+4. Create a function to calculate the number of segments used for a message
 
-    CREATE OR REPLACE FUNCTION SMSCountGSMExt(msg TEXT) RETURNS INT AS $$
-      const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
-      const gsm7bitExOnlyRegExp = RegExp("^[\\" + gsm7bitExChar + "]*$");
-      var char2, chars;
-      chars = (function() {
-        var _i, _len, _results;
-        _results = [];
-        for (_i = 0, _len = msg.length; _i < _len; _i++) {
-          char2 = msg[_i];
-          if (char2.match(this.gsm7bitExOnlyRegExp) != null) {
-            _results.push(char2);
-          }
-        }
-        return _results;
-      }).call(this);
-      return chars.length;
-    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
+CREATE OR REPLACE FUNCTION SMSSegments(msg TEXT) RETURNS INT AS $$
+  const messageLength = {
+    1: 160,
+    2: 160,
+    3: 70
+  };
+  const multiMessageLength = {
+    1: 153,
+    2: 153,
+    3: 67
+  };
+  let fnDetect = plv8.find_function("SMSDetectEncoding", msg);
+  let fnCountExt = plv8.find_function("SMSCountGSMExt", msg);
+  let remaining;
+  const encoding = fnDetect(msg);
+  let length = msg.length;
+  if (encoding === 2) {
+    length += fnCountExt(msg);
+  }
+  let per_message = messageLength[encoding];
+  if (length > per_message) {
+    per_message = multiMessageLength[encoding];
+  }
+  let segments = Math.ceil(length / per_message);
+  remaining = (per_message * segments) - length;
+  if(remaining == 0 && segments == 0){
+    remaining = per_message;
+  }
+  return segments;
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
 
-3. Create a function to calculate the number of segments used for a message
+5. Create a function to calculate the inbound, outbound and total costs for a Spoke campaign
 
-    CREATE OR REPLACE FUNCTION SMSSegments(msg TEXT) RETURNS INT AS $$
-      const messageLength = {
-        1: 160,
-        2: 160,
-        3: 70
-      };
-      const multiMessageLength = {
-        1: 153,
-        2: 153,
-        3: 67
-      };
-      let fnDetect = plv8.find_function("SMSDetectEncoding", msg);
-      let fnCountExt = plv8.find_function("SMSCountGSMExt", msg);
-      let remaining;
-      const encoding = fnDetect(msg);
-      let length = msg.length;
-      if (encoding === 2) {
-        length += fnCountExt(msg);
-      }
-      let per_message = messageLength[encoding];
-      if (length > per_message) {
-        per_message = multiMessageLength[encoding];
-      }
-      let segments = Math.ceil(length / per_message);
-      remaining = (per_message * segments) - length;
-      if(remaining == 0 && segments == 0){
-        remaining = per_message;
-      }
-      return segments;
-    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
+CREATE OR REPLACE FUNCTION SMSCampaignCost(cid INT, obp FLOAT4, ibp FLOAT4) RETURNS JSON AS $$
+  const campaignId = cid;
+  const outboundPrice = obp;
+  const inboundPrice = ibp;
+  let fnCount = plv8.find_function("SMSSegments");
+  const messages = plv8.execute('SELECT m.text, m.is_from_contact FROM message m INNER JOIN campaign_contact cc ON cc.id = m.campaign_contact_id WHERE cc.campaign_id = $1',[ campaignId ]);
 
-4. Create a function to calculate the inbound, outbound and total costs for a Spoke campaign
+  let outboundSegments = 0;
+  let inboundSegments = 0;
+  let outboundCost = 0;
+  let inboundCost = 0;
+  for (let i = 0; i < messages.length; i++) {
+    (messages[i].is_from_contact)
+    ? inboundSegments += fnCount(messages[i].text)
+    : outboundSegments += fnCount(messages[i].text);
+  }
+  outboundCost = +(Math.round((outboundSegments * outboundPrice) + "e+2") + "e-2");
+  inboundCost = +(Math.round((inboundSegments * inboundPrice) + "e+2") + "e-2");
 
-    CREATE OR REPLACE FUNCTION SMSCampaignCost(cid INT, obp FLOAT4, ibp FLOAT4) RETURNS JSON AS $$
-      const campaignId = cid;
-      const outboundPrice = obp;
-      const inboundPrice = ibp;
-      let fnCount = plv8.find_function("SMSSegments");
-      const messages = plv8.execute('SELECT m.text, m.is_from_contact FROM message m INNER JOIN campaign_contact cc ON cc.id = m.campaign_contact_id WHERE cc.campaign_id = $1',[ campaignId ]);
-    
-      let outboundSegments = 0;
-      let inboundSegments = 0;
-      let outboundCost = 0;
-      let inboundCost = 0;
-      for (let i = 0; i < messages.length; i++) {
-        (messages[i].is_from_contact)
-        ? inboundSegments += fnCount(messages[i].text)
-        : outboundSegments += fnCount(messages[i].text);
-      }
-      outboundCost = +(Math.round((outboundSegments * outboundPrice) + "e+2") + "e-2");
-      inboundCost = +(Math.round((inboundSegments * inboundPrice) + "e+2") + "e-2");
-    
-      return {
-        outboundCost: outboundCost,
-        inboundCost: inboundCost,
-        totalCost: outboundCost + inboundCost
-      }
-    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+  return {
+    outboundCost: outboundCost,
+    inboundCost: inboundCost,
+    totalCost: outboundCost + inboundCost
+  }
+$$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
 
 ## Notes
 

--- a/src/extensions/service-managers/campaign-cost-calculator/README.md
+++ b/src/extensions/service-managers/campaign-cost-calculator/README.md
@@ -1,103 +1,168 @@
-// Run the following commands in your Spoke database to set up
-// the required code to support the Twilio Cost Calculator service manager
+# Campaign Cost Service Manager
 
-// 1. Enable the PLV8 language extension
-CREATE EXTENSION plv8;
+This service manager calculates the SMS costs for started (and archived) campaigns.
 
-// 2. Function to detect SMS message encoding
+Importantly, it calculates the cost on the basis of the number of message
+_segments_ used. This ensures a more accurate (though not 100% foolproof) estimate
+of costs.
 
-CREATE OR REPLACE FUNCTION SMSDetectEncoding(msg TEXT) RETURNS INT AS $$
-  const gsm7bitChars = "@£$¥èéùìòÇ\\nØø\\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\\\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
-  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
-  const gsm7bitRegExp = RegExp("^[" + gsm7bitChars + "]*$");
-  const gsm7bitExRegExp = RegExp("^[" + gsm7bitChars + gsm7bitExChar + "]*$");
-  switch (false) {
-    case msg.match(gsm7bitRegExp) == null:
-      return 1;
-    case msg.match(gsm7bitExRegExp) == null:
-      return 2;
-    default:
-      return 3;
-  }
-$$ LANGUAGE plv8 IMMUTABLE STRICT;
+## Requirements
 
-// 3. Function to count extended GSM-7 message length
+- [PostgreSQL](https://www.postgresql.org/)
+- [PL/v8 language extension for PostgreSQL](https://plv8.github.io/)
 
-CREATE OR REPLACE FUNCTION SMSCountGSMExt(msg TEXT) RETURNS INT AS $$
-  const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
-  const gsm7bitExOnlyRegExp = RegExp("^[\\" + gsm7bitExChar + "]*$");
-  var char2, chars;
-  chars = (function() {
-    var _i, _len, _results;
-    _results = [];
-    for (_i = 0, _len = msg.length; _i < _len; _i++) {
-      char2 = msg[_i];
-      if (char2.match(this.gsm7bitExOnlyRegExp) != null) {
-        _results.push(char2);
+This extension has been tested against PostgresSQL 11 specifically.
+Your mileage may vary with other versions.
+
+You will need administrator privileges in your database to perform installation.
+
+## Installation
+
+### Modify your .env file
+
+1. Add `campaign-cost-calculator` to your `SERVICE_MANAGERS` variable
+2. Add `CAMPAIGN_COST_CURRENCY` and assign it a three letter currency code in quotes (eg. `CAMPAIGN_COST_CURRENCY='USD'`)
+3. Add `CAMPAIGN_COST_INBOUND` and assign it the number (eg. `CAMPAIGN_COST_INBOUND=0.0025`)
+4. Add `CAMPAIGN_COST_OUTBOUND` and assign it the outbound pricea (eg. `CAMPAIGN_COST_OUTBOUND=0.055`) 
+
+### Configure PostgreSQL
+
+Use `psql` or your preferred database client and connect as an administrator
+to your postgresql Spoke database. Then run the following commands:
+
+1. Install the PL/v8 language extension
+
+`CREATE EXTENSION plv8;`
+
+    CREATE OR REPLACE FUNCTION SMSDetectEncoding(msg TEXT) RETURNS INT AS $$
+      const gsm7bitChars = "@£$¥èéùìòÇ\\nØø\\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\\\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
+      const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+      const gsm7bitRegExp = RegExp("^[" + gsm7bitChars + "]*$");
+      const gsm7bitExRegExp = RegExp("^[" + gsm7bitChars + gsm7bitExChar + "]*$");
+      switch (false) {
+        case msg.match(gsm7bitRegExp) == null:
+          return 1;
+        case msg.match(gsm7bitExRegExp) == null:
+          return 2;
+        default:
+          return 3;
       }
+    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+2. Create a function to count extended GSM-7 messages
+
+    CREATE OR REPLACE FUNCTION SMSCountGSMExt(msg TEXT) RETURNS INT AS $$
+      const gsm7bitExChar = "\\^{}\\\\\\[~\\]|€";
+      const gsm7bitExOnlyRegExp = RegExp("^[\\" + gsm7bitExChar + "]*$");
+      var char2, chars;
+      chars = (function() {
+        var _i, _len, _results;
+        _results = [];
+        for (_i = 0, _len = msg.length; _i < _len; _i++) {
+          char2 = msg[_i];
+          if (char2.match(this.gsm7bitExOnlyRegExp) != null) {
+            _results.push(char2);
+          }
+        }
+        return _results;
+      }).call(this);
+      return chars.length;
+    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+3. Create a function to calculate the number of segments used for a message
+
+    CREATE OR REPLACE FUNCTION SMSSegments(msg TEXT) RETURNS INT AS $$
+      const messageLength = {
+        1: 160,
+        2: 160,
+        3: 70
+      };
+      const multiMessageLength = {
+        1: 153,
+        2: 153,
+        3: 67
+      };
+      let fnDetect = plv8.find_function("SMSDetectEncoding", msg);
+      let fnCountExt = plv8.find_function("SMSCountGSMExt", msg);
+      let remaining;
+      const encoding = fnDetect(msg);
+      let length = msg.length;
+      if (encoding === 2) {
+        length += fnCountExt(msg);
+      }
+      let per_message = messageLength[encoding];
+      if (length > per_message) {
+        per_message = multiMessageLength[encoding];
+      }
+      let segments = Math.ceil(length / per_message);
+      remaining = (per_message * segments) - length;
+      if(remaining == 0 && segments == 0){
+        remaining = per_message;
+      }
+      return segments;
+    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+4. Create a function to calculate the inbound, outbound and total costs for a Spoke campaign
+
+    CREATE OR REPLACE FUNCTION SMSCampaignCost(cid INT, obp FLOAT4, ibp FLOAT4) RETURNS JSON AS $$
+      const campaignId = cid;
+      const outboundPrice = obp;
+      const inboundPrice = ibp;
+      let fnCount = plv8.find_function("SMSSegments");
+      const messages = plv8.execute('SELECT m.text, m.is_from_contact FROM message m INNER JOIN campaign_contact cc ON cc.id = m.campaign_contact_id WHERE cc.campaign_id = $1',[ campaignId ]);
+    
+      let outboundSegments = 0;
+      let inboundSegments = 0;
+      let outboundCost = 0;
+      let inboundCost = 0;
+      for (let i = 0; i < messages.length; i++) {
+        (messages[i].is_from_contact)
+        ? inboundSegments += fnCount(messages[i].text)
+        : outboundSegments += fnCount(messages[i].text);
+      }
+      outboundCost = +(Math.round((outboundSegments * outboundPrice) + "e+2") + "e-2");
+      inboundCost = +(Math.round((inboundSegments * inboundPrice) + "e+2") + "e-2");
+    
+      return {
+        outboundCost: outboundCost,
+        inboundCost: inboundCost,
+        totalCost: outboundCost + inboundCost
+      }
+    $$ LANGUAGE plv8 IMMUTABLE STRICT;
+
+## Notes
+
+### Use of PL/v8
+
+The PL/v8 language extension is not included by default in PostgreSQL installations.
+It also appears to be an abandoned project. As such, there are plans to rewrite
+the database functions in Python. The PL/Python language extension is included in
+the standard PostgreSQL distribution and therefore more readily available for more
+people.
+
+### Data structure returned from database might be different
+
+While developing this extension it was noted that the structure of the JSON data
+returned by the SMSCampaignCost function to Spoke was slightly different depending
+on the version of PostgreSQL. In particular the JSON object either look like this:
+
+    {
+      smscampaigncost: { outboundCost: 0.3, inboundCost: 0.01, totalCost: 0.31 }
     }
-    return _results;
-  }).call(this);
-  return chars.length;
-$$ LANGUAGE plv8 IMMUTABLE STRICT;
 
-// 4. Calculate number of segments for message
+or looked like this:
 
-CREATE OR REPLACE FUNCTION SMSSegments(msg TEXT) RETURNS INT AS $$
-  const messageLength = {
-    1: 160,
-    2: 160,
-    3: 70
-  };
-  const multiMessageLength = {
-    1: 153,
-    2: 153,
-    3: 67
-  };
-  let fnDetect = plv8.find_function("SMSDetectEncoding", msg);
-  let fnCountExt = plv8.find_function("SMSCountGSMExt", msg);
-  let remaining;
-  const encoding = fnDetect(msg);
-  let length = msg.length;
-  if (encoding === 2) {
-    length += fnCountExt(msg);
-  }
-  let per_message = messageLength[encoding];
-  if (length > per_message) {
-    per_message = multiMessageLength[encoding];
-  }
-  let segments = Math.ceil(length / per_message);
-  remaining = (per_message * segments) - length;
-  if(remaining == 0 && segments == 0){
-    remaining = per_message;
-  }
-  return segments;
-$$ LANGUAGE plv8 IMMUTABLE STRICT;
+    {
+      smscampaigncost: { outboundcost: 0.3, inboundcost: 0.01, totalcost: 0.31 }
+    }
 
-// 5. Calculate total cost of campaign
+This is enough of a change to break the extension. Spoke will still run but
+the extension will report costs as `$undefined USD` or similar.
 
-CREATE OR REPLACE FUNCTION SMSCampaignCost(cid INT, obp FLOAT4, ibp FLOAT4) RETURNS JSON AS $$
-  const campaignId = cid;
-  const outboundPrice = obp;
-  const inboundPrice = ibp;
-  let fnCount = plv8.find_function("SMSSegments");
-  const messages = plv8.execute('SELECT m.text, m.is_from_contact FROM message m INNER JOIN campaign_contact cc ON cc.id = m.campaign_contact_id WHERE cc.campaign_id = $1',[ campaignId ]);
+If you find this to be true in your installation, you may need to modify the contents
+of the `index.js` file (lines 49-51 in particular).
 
-  let outboundSegments = 0;
-  let inboundSegments = 0;
-  let outboundCost = 0;
-  let inboundCost = 0;
-  for (let i = 0; i < messages.length; i++) {
-    (messages[i].is_from_contact)
-    ? inboundSegments += fnCount(messages[i].text)
-    : outboundSegments += fnCount(messages[i].text);
-  }
-  outboundCost = +(Math.round((outboundSegments * outboundPrice) + "e+2") + "e-2");
-  inboundCost = +(Math.round((inboundSegments * inboundPrice) + "e+2") + "e-2");
+## Acknowledgements
 
-  return {
-    outboundCost: outboundCost,
-    inboundCost: inboundCost,
-    totalCost: outboundCost + inboundCost
-  }
-$$ LANGUAGE plv8 IMMUTABLE STRICT;
+The JavaScript code to calculate the number of segments is drawn almost entirely
+verbatim from [danxexe's sms-counter project](https://github.com/danxexe/sms-counter).

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -20,35 +20,44 @@ export async function getCampaignData({
   loaders,
   fromCampaignStatsPage
 }) {
-  // called both from edit and stats contexts: editMode==true for edit page
+  // only display costs on the campaign stats page
   if (fromCampaignStatsPage) {
-    const outboundUnitCost = getConfig("CAMPAIGN_COST_OUTBOUND");
-    const inboundUnitCost = getConfig("CAMPAIGN_COST_INBOUND");
-    const currency = getConfig("CAMPAIGN_COST_CURRENCY");
-    // defaults in case our results are undefined or 0 (ie. no SMS sent/received)
+    const outboundUnitCost = getConfig("CAMPAIGN_COST_OUTBOUND", null, {
+      default: 0.0
+    });
+    const inboundUnitCost = getConfig("CAMPAIGN_COST_INBOUND", null, {
+      default: 0.0
+    });
+    const currency = getConfig("CAMPAIGN_COST_CURRENCY", null, {
+      default: "UND"
+    });
+    const error = currency !== "UND" ? false : true;
+
     let costs = {
-      campaignCosts: {
-        outboundCost: "$0.00 " + currency,
-        inboundCost: "$0.00 " + currency,
-        toalCost: "$0.00 " + currency
-      }
+      outboundCost: "$0.00 " + currency,
+      inboundCost: "$0.00 " + currency,
+      toalCost: "$0.00 " + currency
     };
-    await r.knex
-      .raw("SELECT SMSCampaignCost(?, ?, ?)", [
-        campaign.id,
-        outboundUnitCost,
-        inboundUnitCost
-      ])
-      .then(res => {
-        costs = res.rows[0].smscampaigncost;
-      });
+
+    if (!error) {
+      await r.knex
+        .raw("SELECT SMSCampaignCost(?, ?, ?)", [
+          campaign.id,
+          outboundUnitCost,
+          inboundUnitCost
+        ])
+        .then(res => {
+          costs = res.rows[0].smscampaigncost;
+        });
+    }
 
     return {
       data: {
         campaignCosts: {
           outboundCost: "$" + costs.outboundCost + " " + currency,
           inboundCost: "$" + costs.inboundCost + " " + currency,
-          totalCost: "$" + costs.totalCost + " " + currency
+          totalCost: "$" + costs.totalCost + " " + currency,
+          error
         }
       }
     };

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -32,11 +32,9 @@ export async function getCampaignData({
     ]);
     return {
       data: {
-        costs: {
-          outboundCost: "$" + costs.outboundCost + " " + currency,
-          inboundCost: "$" + costs.inboundCost + " " + currency,
-          totalCost: "$" + costs.totalCost + " " + currency
-        }
+        outboundCost: "$" + costs.outboundCost + " " + currency,
+        inboundCost: "$" + costs.inboundCost + " " + currency,
+        totalCost: "$" + costs.totalCost + " " + currency
       }
     };
   }

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -32,9 +32,11 @@ export async function getCampaignData({
     ]);
     return {
       data: {
-        outboundCost: "$" + costs.outboundCost + " " + currency,
-        inboundCost: "$" + costs.inboundCost + " " + currency,
-        totalCost: "$" + costs.totalCost + " " + currency
+        campaignCosts: {
+          outboundCost: "$" + costs.outboundCost + " " + currency,
+          inboundCost: "$" + costs.inboundCost + " " + currency,
+          totalCost: "$" + costs.totalCost + " " + currency
+        }
       }
     };
   }

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -54,9 +54,9 @@ export async function getCampaignData({
     return {
       data: {
         campaignCosts: {
-          outboundCost: "$" + costs.outboundCost + " " + currency,
-          inboundCost: "$" + costs.inboundCost + " " + currency,
-          totalCost: "$" + costs.totalCost + " " + currency,
+          outboundCost: "$" + costs.outboundcost + " " + currency,
+          inboundCost: "$" + costs.inboundcost + " " + currency,
+          totalCost: "$" + costs.totalcost + " " + currency,
           error
         }
       }

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -1,0 +1,35 @@
+/// All functions are OPTIONAL EXCEPT metadata() and const name=.
+/// DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
+
+export const name = "twilio-cost-calculator";
+
+export const metadata = () => ({
+  // set canSpendMoney=true, if this extension can lead to (additional) money being spent
+  // if it can, which operations below can trigger money being spent?
+  displayName: "Twilio Cost Calculator",
+  description:
+    "Displays campaign costs when using Twilio as your service vendor",
+  canSpendMoney: false,
+  moneySpendingOperations: ["onCampaignStart"],
+  supportsOrgConfig: true,
+  supportsCampaignConfig: true
+});
+
+export async function getCampaignData({
+  organization,
+  campaign,
+  user,
+  loaders,
+  fromCampaignStatsPage
+}) {
+  // called both from edit and stats contexts: editMode==true for edit page
+  if (fromCampaignStatsPage) {
+    const costs = await r.knex.raw("SELECT SMSCampaignCost(?)", [campaign]);
+
+    return {
+      data: {
+        costs: costs
+      }
+    };
+  }
+}

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -41,6 +41,7 @@ export async function getCampaignData({
       ])
       .then(res => {
         costs = res.rows[0].smscampaigncost;
+        console.log(res.rows);
       });
 
     // We have to lowercase the JSON object keys because postgresql

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -54,9 +54,30 @@ export async function getCampaignData({
     return {
       data: {
         campaignCosts: {
-          outboundCost: "$" + costs.outboundcost + " " + currency,
-          inboundCost: "$" + costs.inboundcost + " " + currency,
-          totalCost: "$" + costs.totalcost + " " + currency,
+          outboundCost:
+            new Intl.NumberFormat("en-US", {
+              style: "currency",
+              currency,
+              currencyDisplay: "narrowSymbol"
+            }).format(costs.outboundcost) +
+            " " +
+            currency,
+          inboundCost:
+            new Intl.NumberFormat("en-US", {
+              style: "currency",
+              currency,
+              currencyDisplay: "narrowSymbol"
+            }).format(costs.inboundcost) +
+            " " +
+            currency,
+          totalCost:
+            new Intl.NumberFormat("en-US", {
+              style: "currency",
+              currency,
+              currencyDisplay: "narrowSymbol"
+            }).format(costs.totalcost) +
+            " " +
+            currency,
           error
         }
       }

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -1,18 +1,16 @@
-/// All functions are OPTIONAL EXCEPT metadata() and const name=.
-/// DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
+import { r } from "../../../server/models";
+import { getConfig } from "../../../server/api/lib/config";
 
-export const name = "twilio-cost-calculator";
+export const name = "campaign-cost-calculator";
 
 export const metadata = () => ({
-  // set canSpendMoney=true, if this extension can lead to (additional) money being spent
-  // if it can, which operations below can trigger money being spent?
-  displayName: "Twilio Cost Calculator",
+  displayName: "Campaign Cost Calculator",
   description:
-    "Displays campaign costs when using Twilio as your service vendor",
+    "Displays costs for outbound and inbound messages in campaign states",
   canSpendMoney: false,
   moneySpendingOperations: ["onCampaignStart"],
   supportsOrgConfig: true,
-  supportsCampaignConfig: true
+  supportsCampaignConfig: false
 });
 
 export async function getCampaignData({
@@ -23,13 +21,42 @@ export async function getCampaignData({
   fromCampaignStatsPage
 }) {
   // called both from edit and stats contexts: editMode==true for edit page
-  if (fromCampaignStatsPage) {
-    const costs = await r.knex.raw("SELECT SMSCampaignCost(?)", [campaign]);
+  //  if (fromCampaignStatsPage) {
+  //    const costs = await r.knex.raw("SELECT SMSCampaignCost(?)", [campaign]);
+  //
+  //    return {
+  //      data: {
+  //        costs: costs
+  //      }
+  //    };
+  //  }
+}
 
-    return {
-      data: {
-        costs: costs
-      }
-    };
-  }
+export async function getOrganizationData({ organization, user, loaders }) {
+  const features = getFeatures(organization);
+  const {
+    calcCampaignOutboundCost = null,
+    calcCampaignInboundCost = null,
+    calcCampaignCurrency = null
+  } = features;
+
+  return {
+    data: {
+      inboundCost: organization.features.inboundCost,
+      outboundCost: organization.features.outboundCost,
+      currency: organization.features.currency
+    },
+    fullyConfigured: null
+  };
+}
+
+export async function onOrganizationUpdateSignal({
+  organization,
+  user,
+  updateData
+}) {
+  return {
+    data: updateData,
+    fullyConfigured: true
+  };
 }

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -41,17 +41,14 @@ export async function getCampaignData({
       ])
       .then(res => {
         costs = res.rows[0].smscampaigncost;
-        console.log(res.rows);
       });
 
-    // We have to lowercase the JSON object keys because postgresql
-    // returns them in all lowercase
     return {
       data: {
         campaignCosts: {
-          outboundCost: "$" + costs.outboundcost + " " + currency,
-          inboundCost: "$" + costs.inboundcost + " " + currency,
-          totalCost: "$" + costs.totalcost + " " + currency
+          outboundCost: "$" + costs.outboundCost + " " + currency,
+          inboundCost: "$" + costs.inboundCost + " " + currency,
+          totalCost: "$" + costs.totalCost + " " + currency
         }
       }
     };

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -33,9 +33,9 @@ export async function getCampaignData({
     return {
       data: {
         costs: {
-          outboundCost: "$" + costs.outboundCost + " USD",
-          inboundCost: "$" + costs.inboundCost + " USD",
-          totalCost: "$" + costs.totalCost + " USD"
+          outboundCost: "$" + costs.outboundCost + " " + currency,
+          inboundCost: "$" + costs.inboundCost + " " + currency,
+          totalCost: "$" + costs.totalCost + " " + currency
         }
       }
     };

--- a/src/extensions/service-managers/campaign-cost-calculator/index.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/index.js
@@ -21,42 +21,23 @@ export async function getCampaignData({
   fromCampaignStatsPage
 }) {
   // called both from edit and stats contexts: editMode==true for edit page
-  //  if (fromCampaignStatsPage) {
-  //    const costs = await r.knex.raw("SELECT SMSCampaignCost(?)", [campaign]);
-  //
-  //    return {
-  //      data: {
-  //        costs: costs
-  //      }
-  //    };
-  //  }
-}
-
-export async function getOrganizationData({ organization, user, loaders }) {
-  const features = getFeatures(organization);
-  const {
-    calcCampaignOutboundCost = null,
-    calcCampaignInboundCost = null,
-    calcCampaignCurrency = null
-  } = features;
-
-  return {
-    data: {
-      inboundCost: organization.features.inboundCost,
-      outboundCost: organization.features.outboundCost,
-      currency: organization.features.currency
-    },
-    fullyConfigured: null
-  };
-}
-
-export async function onOrganizationUpdateSignal({
-  organization,
-  user,
-  updateData
-}) {
-  return {
-    data: updateData,
-    fullyConfigured: true
-  };
+  if (fromCampaignStatsPage) {
+    const outboundUnitCost = getConfig("CAMPAIGN_COST_OUTBOUND");
+    const inboundUnitCost = getConfig("CAMPAIGN_COST_INBOUND");
+    const currency = getConfig("CAMPAIGN_COST_CURRENCY");
+    const costs = await r.knex.raw("SELECT SMSCampaignCost(?, ?, ?)", [
+      campaign,
+      outboundUnitCost,
+      inboundUnitCost
+    ]);
+    return {
+      data: {
+        costs: {
+          outboundCost: "$" + costs.outboundCost + " USD",
+          inboundCost: "$" + costs.inboundCost + " USD",
+          totalCost: "$" + costs.totalCost + " USD"
+        }
+      }
+    };
+  }
 }

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -9,6 +9,29 @@ export const styles = StyleSheet.create({
     ...theme.text.header
   }
 });
+
+const DisplayCostError = () => {
+  return (
+    <div>
+      Warning: The campaign cost calculator service-manager extension is
+      misconfigured. <br />
+      Please ask your system administrator to review the Spoke .env file.
+    </div>
+  );
+};
+
+const DisplayCostData = props => {
+  const { outboundCost, inboundCost, totalCost } = props.data;
+  return (
+    <div>
+      Outbound cost: {outboundCost} <br />
+      Inbound cost: {inboundCost} <br />
+      Total cost: {totalCost} <br />
+      NB: these costs estimates may be <em>very slightly</em> inaccurate and do
+      not include phone rental costs.
+    </div>
+  );
+};
 export class CampaignStats extends React.Component {
   constructor(props) {
     super(props);
@@ -16,22 +39,22 @@ export class CampaignStats extends React.Component {
   }
 
   render() {
-    console.log("campaign-cost-calculator CampaignStats", this.props);
     const {
-      outboundCost,
-      inboundCost,
-      totalCost
+      error,
+      ...campaignCosts
     } = this.props.serviceManagerInfo.data.campaignCosts;
+
+    let content;
+    if (error) {
+      content = <DisplayCostError />;
+    } else {
+      content = <DisplayCostData data={campaignCosts} />;
+    }
+
     return (
       <div>
         <div className={css(styles.header)}>Campaign Costs</div>
-        <div>
-          Outbound cost: {outboundCost} <br />
-          Inbound cost: {inboundCost} <br />
-          Total cost: {totalCost} <br />
-          NB: these costs estimates may be <em>very slightly</em> inaccurate and
-          do not include phone rental costs.
-        </div>
+        {content}
       </div>
     );
   }

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -1,0 +1,165 @@
+/* eslint no-console: 0 */
+import { css } from "aphrodite";
+import PropTypes from "prop-types";
+import React from "react";
+import Form from "react-formal";
+import * as yup from "yup";
+import DisplayLink from "../../../components/DisplayLink";
+import GSForm from "../../../components/forms/GSForm";
+import GSTextField from "../../../components/forms/GSTextField";
+import GSSubmitButton from "../../../components/forms/GSSubmitButton";
+
+export class OrgConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    console.log("testfakedata OrgConfig", this.props);
+    const formSchema = yup.object({
+      savedText: yup
+        .string()
+        .nullable()
+        .max(64)
+    });
+    return (
+      <div>
+        THIS IS TEST_FAKE_DATA
+        <GSForm
+          schema={formSchema}
+          defaultValue={this.props.serviceManagerInfo.data}
+          onSubmit={x => {
+            console.log("onSubmit", x);
+            this.props.onSubmit(x);
+          }}
+        >
+          <Form.Field
+            as={GSTextField}
+            label="Some saveable text"
+            name="savedText"
+            fullWidth
+          />
+          <Form.Submit
+            as={GSSubmitButton}
+            label="Save"
+            style={this.props.inlineStyles.dialogButton}
+          />
+        </GSForm>
+      </div>
+    );
+  }
+}
+
+OrgConfig.propTypes = {
+  organizationId: PropTypes.string,
+  serviceManagerInfo: PropTypes.object,
+  inlineStyles: PropTypes.object,
+  styles: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};
+
+export class CampaignConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    console.log("testfakedata CampaignConfig", this.props);
+    const foo =
+      this.props.serviceManagerInfo &&
+      this.props.serviceManagerInfo.data &&
+      this.props.serviceManagerInfo.data.foo;
+    const formSchema = yup.object({
+      savedText: yup
+        .string()
+        .nullable()
+        .max(64)
+    });
+    return (
+      <div>
+        THIS IS TEST_FAKE_DATA
+        {!this.props.campaign.isStarted ? (
+          <GSForm
+            schema={formSchema}
+            defaultValue={
+              (this.props.serviceManagerInfo &&
+                this.props.serviceManagerInfo.data) ||
+              {}
+            }
+            onSubmit={x => {
+              console.log("onSubmit", x);
+              this.props.onSubmit(x);
+            }}
+          >
+            <Form.Field
+              as={GSTextField}
+              label="Some saveable text"
+              name="savedText"
+              fullWidth
+            />
+            <Form.Submit as={GSSubmitButton} label="Save" />
+          </GSForm>
+        ) : (
+          <div>Campaign is now started! {foo}</div>
+        )}
+      </div>
+    );
+  }
+}
+
+CampaignConfig.propTypes = {
+  user: PropTypes.object,
+  campaign: PropTypes.object,
+  serviceManagerInfo: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};
+
+export class CampaignStats extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    console.log("testfakedata CampaignStats", this.props);
+    const foo =
+      this.props.serviceManagerInfo &&
+      this.props.serviceManagerInfo.data &&
+      this.props.serviceManagerInfo.data.foo;
+    const formSchema = yup.object({});
+    return (
+      <div>
+        THIS IS TEST_FAKE_DATA {foo}
+        {!this.props.campaign.isStarted ? (
+          <GSForm
+            schema={formSchema}
+            onSubmit={x => {
+              console.log("onSubmit", x);
+              this.props.onSubmit({ a: "b" });
+            }}
+          >
+            <Form.Submit
+              as={GSSubmitButton}
+              label="Beep Boop"
+              component={GSSubmitButton}
+            />
+          </GSForm>
+        ) : (
+          <div>Campaign is now started! {foo}</div>
+        )}
+      </div>
+    );
+  }
+}
+
+CampaignStats.propTypes = {
+  user: PropTypes.object,
+  campaign: PropTypes.object,
+  serviceManagerInfo: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -24,9 +24,9 @@ const DisplayCostData = props => {
   const { outboundcost, inboundcost, totalcost } = props.data;
   return (
     <div>
-      Outbound cost: {outboundcost} <br />
-      Inbound cost: {inboundcost} <br />
-      Total cost: {totalcost} <br />
+      Outbound cost: {outboundCost} <br />
+      Inbound cost: {inboundCost} <br />
+      Total cost: {totalCost} <br />
       NB: these costs estimates may be <em>very slightly</em> inaccurate and do
       not include phone rental costs.
     </div>

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -16,6 +16,7 @@ export class CampaignStats extends React.Component {
       this.props.serviceManagerInfo && this.props.serviceManagerInfo.data;
     return (
       <div>
+        Campaign cost estimates: <br />
         Outbound cost: {outboundCost} <br />
         Inbound cost: {inboundCost} <br />
         Total cost: {totalCost}

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -1,9 +1,14 @@
 /* eslint no-console: 0 */
-import { css } from "aphrodite";
-import PropTypes from "prop-types";
 import React from "react";
-import Form from "react-formal";
+import PropTypes from "prop-types";
+import { StyleSheet, css } from "aphrodite";
+import theme from "../../../styles/theme";
 
+export const styles = StyleSheet.create({
+  header: {
+    ...theme.text.header
+  }
+});
 export class CampaignStats extends React.Component {
   constructor(props) {
     super(props);
@@ -12,14 +17,21 @@ export class CampaignStats extends React.Component {
 
   render() {
     console.log("campaign-cost-calculator CampaignStats", this.props);
-    const { outboundCost, inboundCost, totalCost } =
-      this.props.serviceManagerInfo && this.props.serviceManagerInfo.data;
+    const {
+      outboundCost,
+      inboundCost,
+      totalCost
+    } = this.props.serviceManagerInfo.data;
     return (
       <div>
-        Campaign cost estimates: <br />
-        Outbound cost: {outboundCost} <br />
-        Inbound cost: {inboundCost} <br />
-        Total cost: {totalCost}
+        <div className={css(styles.header)}>Campaign Costs</div>
+        <div>
+          Outbound cost: {outboundCost} <br />
+          Inbound cost: {inboundCost} <br />
+          Total cost: {totalCost} <br />
+          NB: these costs estimates may be <em>very slightly</em> inaccurate and
+          do not include phone rental costs.
+        </div>
       </div>
     );
   }

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -16,16 +16,26 @@ export class OrgConfig extends React.Component {
   }
 
   render() {
-    console.log("testfakedata OrgConfig", this.props);
+    console.log("campaign-cost-calculator OrgConfig", this.props);
     const formSchema = yup.object({
-      savedText: yup
-        .string()
+      outboundCost: yup
+        .number()
         .nullable()
-        .max(64)
+        .positive(),
+      inboundCost: yup
+        .number()
+        .nullable()
+        .positive(),
+      currency: yup
+        .string()
+        .max(3)
+        .nullable()
+        .uppercase()
     });
     return (
       <div>
-        THIS IS TEST_FAKE_DATA
+        Set the currency and cost per inbound and outbound SMS message segment
+        here to show SMS costs in the campaign stats section
         <GSForm
           schema={formSchema}
           defaultValue={this.props.serviceManagerInfo.data}
@@ -36,8 +46,20 @@ export class OrgConfig extends React.Component {
         >
           <Form.Field
             as={GSTextField}
-            label="Some saveable text"
-            name="savedText"
+            label="Cost per outbound SMS segment (eg. 0.0075)"
+            name="outboundCost"
+            fullWidth
+          />
+          <Form.Field
+            as={GSTextField}
+            label="Cost per inbound SMS segment (eg. 0.00049)"
+            name="inboundCost"
+            fullWidth
+          />
+          <Form.Field
+            as={GSTextField}
+            label="Currency (eg. AUD, EUR, USD, etc.)"
+            name="currency"
             fullWidth
           />
           <Form.Submit
@@ -56,110 +78,6 @@ OrgConfig.propTypes = {
   serviceManagerInfo: PropTypes.object,
   inlineStyles: PropTypes.object,
   styles: PropTypes.object,
-  saveLabel: PropTypes.string,
-  onSubmit: PropTypes.func
-};
-
-export class CampaignConfig extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
-  render() {
-    console.log("testfakedata CampaignConfig", this.props);
-    const foo =
-      this.props.serviceManagerInfo &&
-      this.props.serviceManagerInfo.data &&
-      this.props.serviceManagerInfo.data.foo;
-    const formSchema = yup.object({
-      savedText: yup
-        .string()
-        .nullable()
-        .max(64)
-    });
-    return (
-      <div>
-        THIS IS TEST_FAKE_DATA
-        {!this.props.campaign.isStarted ? (
-          <GSForm
-            schema={formSchema}
-            defaultValue={
-              (this.props.serviceManagerInfo &&
-                this.props.serviceManagerInfo.data) ||
-              {}
-            }
-            onSubmit={x => {
-              console.log("onSubmit", x);
-              this.props.onSubmit(x);
-            }}
-          >
-            <Form.Field
-              as={GSTextField}
-              label="Some saveable text"
-              name="savedText"
-              fullWidth
-            />
-            <Form.Submit as={GSSubmitButton} label="Save" />
-          </GSForm>
-        ) : (
-          <div>Campaign is now started! {foo}</div>
-        )}
-      </div>
-    );
-  }
-}
-
-CampaignConfig.propTypes = {
-  user: PropTypes.object,
-  campaign: PropTypes.object,
-  serviceManagerInfo: PropTypes.object,
-  saveLabel: PropTypes.string,
-  onSubmit: PropTypes.func
-};
-
-export class CampaignStats extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
-  render() {
-    console.log("testfakedata CampaignStats", this.props);
-    const foo =
-      this.props.serviceManagerInfo &&
-      this.props.serviceManagerInfo.data &&
-      this.props.serviceManagerInfo.data.foo;
-    const formSchema = yup.object({});
-    return (
-      <div>
-        THIS IS TEST_FAKE_DATA {foo}
-        {!this.props.campaign.isStarted ? (
-          <GSForm
-            schema={formSchema}
-            onSubmit={x => {
-              console.log("onSubmit", x);
-              this.props.onSubmit({ a: "b" });
-            }}
-          >
-            <Form.Submit
-              as={GSSubmitButton}
-              label="Beep Boop"
-              component={GSSubmitButton}
-            />
-          </GSForm>
-        ) : (
-          <div>Campaign is now started! {foo}</div>
-        )}
-      </div>
-    );
-  }
-}
-
-CampaignStats.propTypes = {
-  user: PropTypes.object,
-  campaign: PropTypes.object,
-  serviceManagerInfo: PropTypes.object,
   saveLabel: PropTypes.string,
   onSubmit: PropTypes.func
 };

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -21,7 +21,7 @@ const DisplayCostError = () => {
 };
 
 const DisplayCostData = props => {
-  const { outboundcost, inboundcost, totalcost } = props.data;
+  const { outboundCost, inboundCost, totalCost } = props.data;
   return (
     <div>
       Outbound cost: {outboundCost} <br />

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -21,12 +21,12 @@ const DisplayCostError = () => {
 };
 
 const DisplayCostData = props => {
-  const { outboundCost, inboundCost, totalCost } = props.data;
+  const { outboundcost, inboundcost, totalcost } = props.data;
   return (
     <div>
-      Outbound cost: {outboundCost} <br />
-      Inbound cost: {inboundCost} <br />
-      Total cost: {totalCost} <br />
+      Outbound cost: {outboundcost} <br />
+      Inbound cost: {inboundcost} <br />
+      Total cost: {totalcost} <br />
       NB: these costs estimates may be <em>very slightly</em> inaccurate and do
       not include phone rental costs.
     </div>

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -3,81 +3,31 @@ import { css } from "aphrodite";
 import PropTypes from "prop-types";
 import React from "react";
 import Form from "react-formal";
-import * as yup from "yup";
-import DisplayLink from "../../../components/DisplayLink";
-import GSForm from "../../../components/forms/GSForm";
-import GSTextField from "../../../components/forms/GSTextField";
-import GSSubmitButton from "../../../components/forms/GSSubmitButton";
 
-export class OrgConfig extends React.Component {
+export class CampaignStats extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
   }
 
   render() {
-    console.log("campaign-cost-calculator OrgConfig", this.props);
-    const formSchema = yup.object({
-      outboundCost: yup
-        .number()
-        .nullable()
-        .positive(),
-      inboundCost: yup
-        .number()
-        .nullable()
-        .positive(),
-      currency: yup
-        .string()
-        .max(3)
-        .nullable()
-        .uppercase()
-    });
+    console.log("campaign-cost-calculator CampaignStats", this.props);
+    const { outboundCost, inboundCost, totalCost } =
+      this.props.serviceManagerInfo && this.props.serviceManagerInfo.data;
     return (
       <div>
-        Set the currency and cost per inbound and outbound SMS message segment
-        here to show SMS costs in the campaign stats section
-        <GSForm
-          schema={formSchema}
-          defaultValue={this.props.serviceManagerInfo.data}
-          onSubmit={x => {
-            console.log("onSubmit", x);
-            this.props.onSubmit(x);
-          }}
-        >
-          <Form.Field
-            as={GSTextField}
-            label="Cost per outbound SMS segment (eg. 0.0075)"
-            name="outboundCost"
-            fullWidth
-          />
-          <Form.Field
-            as={GSTextField}
-            label="Cost per inbound SMS segment (eg. 0.00049)"
-            name="inboundCost"
-            fullWidth
-          />
-          <Form.Field
-            as={GSTextField}
-            label="Currency (eg. AUD, EUR, USD, etc.)"
-            name="currency"
-            fullWidth
-          />
-          <Form.Submit
-            as={GSSubmitButton}
-            label="Save"
-            style={this.props.inlineStyles.dialogButton}
-          />
-        </GSForm>
+        Outbound cost: {outboundCost} <br />
+        Inbound cost: {inboundCost} <br />
+        Total cost: {totalCost}
       </div>
     );
   }
 }
 
-OrgConfig.propTypes = {
-  organizationId: PropTypes.string,
+CampaignStats.propTypes = {
+  user: PropTypes.object,
+  campaign: PropTypes.object,
   serviceManagerInfo: PropTypes.object,
-  inlineStyles: PropTypes.object,
-  styles: PropTypes.object,
   saveLabel: PropTypes.string,
   onSubmit: PropTypes.func
 };

--- a/src/extensions/service-managers/campaign-cost-calculator/react-component.js
+++ b/src/extensions/service-managers/campaign-cost-calculator/react-component.js
@@ -21,7 +21,7 @@ export class CampaignStats extends React.Component {
       outboundCost,
       inboundCost,
       totalCost
-    } = this.props.serviceManagerInfo.data;
+    } = this.props.serviceManagerInfo.data.campaignCosts;
     return (
       <div>
         <div className={css(styles.header)}>Campaign Costs</div>


### PR DESCRIPTION
## Description

Adds a Service Manager that calculates inbound, outbound and total SMS costs for active or archived campaigns.

It has specific requirements to be function, most notably the inclusion of the PL/v8 language extension for PostgreSQL.

All requirements and installation instructions are noted in a README.md file.

The extension is released under the MIT license.