### PR TITLE
[no-jira] Require last_name and postal_code to be not-null when retri…

### DIFF
--- a/src/extensions/contact-loaders/civicrm/util.js
+++ b/src/extensions/contact-loaders/civicrm/util.js
@@ -155,6 +155,8 @@ export async function getGroupMembers(groupId, callback) {
       sequential: 1,
       options: { limit: CIVICRM_PAGINATE_SIZE },
       first_name: { "IS NOT NULL": 1 },
+      last_name: { "IS NOT NULL": 1 },
+      postal_code: { "IS NOT NULL": 1 },
       do_not_sms: { "=": 0 },
       is_deleted: { "=": 0 },
       is_deceased: { "=": 0 },


### PR DESCRIPTION
Require last_name and postal_code to be not null when retrieving from civicrm

# Fixes # (issue)
Previously the not-null criteria was only being apply to first_name when using the civicrm contact loader. This causes errors because the spoke database has a not-null constraint on last_name and postal_code as well. Therefore we add this as a requirement.

## Description

Modified getGroupMembers() in contact-loaders/util.js, adding more criteria to the civicrm api call.

